### PR TITLE
Changed the $customer->getStoreId() call to $customer->getData('store…

### DIFF
--- a/Controller/Adminhtml/Login/Login.php
+++ b/Controller/Adminhtml/Login/Login.php
@@ -38,9 +38,12 @@ class Login extends \Magento\Backend\App\Action
 
         $user = $this->_objectManager->get('Magento\Backend\Model\Auth\Session')->getUser();
         $login->generate($user->getId());
+        // We're not using the $customer->getStoreId() method due to a bug where it returns the store for the customer's
+        // website
+        $customerStoreId = $customer->getData('store_id');
 
         $store = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface')
-            ->getStore($customer->getStoreId());
+            ->getStore($customerStoreId);
         $url = $this->_objectManager->get('Magento\Framework\Url')
             ->setScope($store);
 


### PR DESCRIPTION
Changed the $customer->getStoreId() call to $customer->getData('store_id') to bypass the Magento bug where it will get the default store for the website.

### Fixes #8(https://github.com/magefan/module-login-as-customer/issues/8)