### PR TITLE
Create seperate method for getting store id

### DIFF
--- a/Controller/Adminhtml/Login/Login.php
+++ b/Controller/Adminhtml/Login/Login.php
@@ -38,9 +38,8 @@ class Login extends \Magento\Backend\App\Action
 
         $user = $this->_objectManager->get(\Magento\Backend\Model\Auth\Session::class)->getUser();
         $login->generate($user->getId());
-        // We're not using the $customer->getStoreId() method due to a bug where it returns the store for the customer's
-        // website
-        $customerStoreId = $customer->getData('store_id');
+        $customerStoreId = $this->getCustomerStoreId($customer);
+
         $storeManager = $this->_objectManager->get(\Magento\Store\Model\StoreManagerInterface::class);
 
         if ($customerStoreId) {
@@ -55,6 +54,16 @@ class Login extends \Magento\Backend\App\Action
         $redirectUrl = $url->getUrl('loginascustomer/login/index', ['secret' => $login->getSecret(), '_nosid' => true]);
 
         $this->getResponse()->setRedirect($redirectUrl);
+    }
+
+    /**
+     * We're not using the $customer->getStoreId() method due to a bug where it returns the store for the customer's website
+     * @param $customer
+     * @return string
+     */
+    public function getCustomerStoreId(\Magento\Customer\Model\Customer $customer)
+    {
+        return $customer->getData('store_id');
     }
 
     /**


### PR DESCRIPTION
Let's extract ` $customer->getData('store_id')` to a seperate public method, so it can be pluginized by other modules. If we want to change the target store view, for example, using a 'before' plugin we can call the `beforeGetCustomerStoreId` method.